### PR TITLE
feat: Added ability to change api_key through reconfig (options) flow

### DIFF
--- a/custom_components/parcelapp/manifest.json
+++ b/custom_components/parcelapp/manifest.json
@@ -8,5 +8,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/jmdevita/parcel-ha/issues",
     "requirements": ["requests>=2.32.3"],
-    "version": "1.0.0"
+    "version": "1.0.1"
 }


### PR DESCRIPTION
From #11, users can now reconfigure and save their API key. This keeps all checking processes (invalid api key, etc) as with the initial configuration.

<img width="694" alt="Screenshot 2025-03-18 at 9 41 35 PM" src="https://github.com/user-attachments/assets/282bfca4-a502-47ac-95fa-ff017769ec98" />


<img width="796" alt="Screenshot 2025-03-18 at 9 41 55 PM" src="https://github.com/user-attachments/assets/bdefd038-1da0-44fb-8898-08bb258fd6e3" />
