### PR TITLE
fix: Fixed unloading/loading error of certain parcel sensors

### DIFF
--- a/custom_components/parcelapp/manifest.json
+++ b/custom_components/parcelapp/manifest.json
@@ -8,5 +8,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/jmdevita/parcel-ha/issues",
     "requirements": ["requests>=2.32.3"],
-    "version": "1.2.0"
+    "version": "1.2.1"
 }

--- a/custom_components/parcelapp/sensor.py
+++ b/custom_components/parcelapp/sensor.py
@@ -32,7 +32,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Parcel sensor platform from a config entry."""
-    coordinator = hass.data[DOMAIN]["coordinator"]
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
     async_add_entities(
         [
             RecentShipment(coordinator),
@@ -97,9 +97,6 @@ class RecentShipment(SensorEntity):
             try:
                 status = DELIVERY_STATUS_CODES[data[0]["status_code"]]
                 self._attr_state = status
-                # If the parcel is delivered, report the delivery date instead of "Unknown"
-                if data[0]["status_code"] == 0:
-                    date_expected = event_date
             except:
                 status = "Unknown"
                 self._attr_state = status


### PR DESCRIPTION
When attempting to enable the raw parcel data sensor, the parcel app would sometimes have an error saying that it is already enabled (when it isn't).

Ways to Test:
- Load branch into testing server
- Enable Parcel App
- Enable Parcel Raw Sensor
- Wait 30 seconds
- See sensor load correctly

This should resolve Issue #21 