### PR TITLE
 fix: Added a no shipments catch.

### DIFF
--- a/custom_components/parcelapp/const.py
+++ b/custom_components/parcelapp/const.py
@@ -63,3 +63,16 @@ EMPTY_SHIPMENT = Shipment(
         }
     ]
     )
+EMPTY_ATTRIBUTES = {
+    "number_of_active_parcels": 0,
+    "parcels_arriving_today": 0,
+    "full_description": "No description",
+    "tracking_number": "None",
+    "date_expected": "None",
+    "days_until_next_delivery": "No active parcels.",
+    "event": "None",
+    "event_date": "None",
+    "event_location": "None",
+    "next_delivery_status": "None",
+    "next_delivery_carrier": "None",
+    }

--- a/custom_components/parcelapp/manifest.json
+++ b/custom_components/parcelapp/manifest.json
@@ -8,5 +8,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/jmdevita/parcel-ha/issues",
     "requirements": ["requests>=2.32.3"],
-    "version": "1.2.1"
+    "version": "1.2.2"
 }

--- a/custom_components/parcelapp/sensor.py
+++ b/custom_components/parcelapp/sensor.py
@@ -17,6 +17,7 @@ from .const import (
     DELIVERY_STATUS_CODES,
     Shipment,
     EMPTY_SHIPMENT,
+    EMPTY_ATTRIBUTES,
 )
 from .coordinator import ParcelConfigEntry, ParcelUpdateCoordinator
 
@@ -71,7 +72,11 @@ class RecentShipment(SensorEntity):
         await self.coordinator.async_request_refresh()
         parcel_api_data = self.coordinator.data
 
-        if parcel_api_data["deliveries"]:
+        if parcel_api_data["deliveries"] == []:
+            self._attr_state = "No parcels for now.."
+            self._attr_icon = "mdi:close-circle"
+            self._hass_custom_attributes = EMPTY_ATTRIBUTES
+        elif parcel_api_data["deliveries"]:
             data = parcel_api_data["deliveries"]
             carrier_codes = parcel_api_data["carrier_codes"]
             try:
@@ -147,7 +152,12 @@ class ActiveShipment(SensorEntity):
         active_shipments = []
         traceable_active_shipments = []
         today = date.today()
-        if parcel_api_data["deliveries"]:
+
+        if parcel_api_data["deliveries"] == []:
+            self._attr_state = "No parcels for now.."
+            self._attr_icon = "mdi:close-circle"
+            self._hass_custom_attributes = EMPTY_ATTRIBUTES
+        elif parcel_api_data["deliveries"]:
             data = parcel_api_data["deliveries"]
             carrier_codes = parcel_api_data["carrier_codes"]
             for item in data:


### PR DESCRIPTION
Relatively simple addition to check for the empty list. I believe if the API fails there will be no "delivery" key so the failure should still be caught properly.