### PR TITLE
feat: added system health configuration to show connected status.

### DIFF
--- a/custom_components/parcelapp/system_health.py
+++ b/custom_components/parcelapp/system_health.py
@@ -1,0 +1,26 @@
+"""Provide info to system health."""
+
+import os
+from typing import Any
+
+from homeassistant.components import system_health
+from homeassistant.core import HomeAssistant, callback
+from .const import DOMAIN, PARCEL_URL
+from .coordinator import ParcelConfigEntry
+
+
+@callback
+def async_register(hass: HomeAssistant, register: system_health.SystemHealthRegistration) -> None:
+    """Register system health callbacks."""
+    register.async_register_info(system_health_info)
+
+async def system_health_info(hass: HomeAssistant) -> dict[str, Any]:
+    """Get info for the info page."""
+    config_entry: ParcelConfigEntry = hass.config_entries.async_entries(DOMAIN)[0]
+    # quota_info = await config_entry.runtime_data.async_get_quota_info()
+
+    return {
+        # "consumed_requests": quota_info.consumed_requests,
+        # "remaining_requests": quota_info.requests_remaining,
+        "can_reach_server": system_health.async_check_can_reach_url(hass, PARCEL_URL),
+    }

--- a/custom_components/parcelapp/translations/en.json
+++ b/custom_components/parcelapp/translations/en.json
@@ -82,5 +82,10 @@
                 }
             }
         }
+    },
+    "system_health": {
+        "info": {
+            "can_reach_server": "Reach Parcel server"
+        }
     }
 }


### PR DESCRIPTION
@jmdevita - discovered system_health, though I'm not sure how worthwhile it is - I've added effectively an 'is connected' entry that can be checked via settings > repairs > three dots > system information.

I THINK if it wasn't connected it might show in repairs.. What I *really* wanted to do was include info about how many API calls had been made that hour.. but sadly the API doesn't supply that info so we'd have to work out how to count the number of calls in an hour.. which sounds fiddly and difficult =/