### PR TITLE
fix: run carrier detection load() in executor

### DIFF
--- a/custom_components/parcelapp/carrier_detection.py
+++ b/custom_components/parcelapp/carrier_detection.py
@@ -342,9 +342,6 @@ class CarrierDetector:
 
         Returns matches sorted by confidence (highest first).
         """
-        if not self._loaded:
-            self.load()
-
         results: list[CarrierMatch] = []
 
         for pattern in self._patterns:

--- a/custom_components/parcelapp/services.py
+++ b/custom_components/parcelapp/services.py
@@ -243,7 +243,7 @@ async def async_register_services(hass: HomeAssistant):
 
     session = async_get_clientsession(hass)
     detector = CarrierDetector()
-    detector.load()
+    await hass.async_add_executor_job(detector.load)
 
     async def async_add_parcel(call: ServiceCall):
         """Add a parcel to ParcelApp using the official API."""


### PR DESCRIPTION
To avoid blocking event loop

Offload the blocking filesystem I/O (scandir, read_text, open) in CarrierDetector.load() to the executor via hass.async_add_executor_job, preventing HA from logging blocking call warnings. Also removes the lazy-load fallback in detect() to ensure load() is never called synchronously from the event loop.

Fixes #84