### PR TITLE
docs: update raw shipment sensor entity id in bubble_card template

### DIFF
--- a/docs/community_templates/bubble_card.yaml
+++ b/docs/community_templates/bubble_card.yaml
@@ -3,7 +3,7 @@
 
 type: markdown
 content: >-
-  {% set raw = state_attr('sensor.parcel_raw_shipment_data', 'deliveries') %}
+  {% set raw = state_attr('sensor.parcel_app_parcel_raw_shipment_data', 'deliveries') %}
   {% set ns = namespace(deliveries = []) %}
   {% for order in raw | selectattr('status_code','>',0) %}
     {% if order.date_expected is defined %}


### PR DESCRIPTION
The community template `docs/community_templates/bubble_card.yaml` still
references the old entity id `sensor.parcel_raw_shipment_data`.

Since the integration now creates the sensor as
`sensor.parcel_app_parcel_raw_shipment_data`, the template renders
empty for new installations (state_attr returns None).

This PR updates the entity id in the template accordingly.
Tested against v1.8.2 on Home Assistant 2026.8.