### PR TITLE
docs: update raw shipment sensor entity id in community templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This integration includes beta features for adding, editing, and deleting parcel
 -   `next_delivery_carrier`: The converted (from carrier code) carrier name of the next shipment arriving.
 
 ### Raw Data Sensor
-From v1.2.0 another sensor entity is added, called `sensor.parcel_raw_shipment_data`. It contains raw json data from the API pull for debugging or custom templating. It has the following attributes:
+From v1.2.0 another sensor entity is added, called `sensor.parcel_app_parcel_raw_shipment_data`. It contains raw json data from the API pull for debugging or custom templating. It has the following attributes:
 
 #### Raw Data Sensor Attributes
 As per the [Parcel App API documentation](https://parcelapp.net/help/api.html)

--- a/docs/community_templates/auto_entities.yaml
+++ b/docs/community_templates/auto_entities.yaml
@@ -8,7 +8,7 @@ card:
 filter:
   template: >
     {# Fetch parcel data from sensor #}
-    {% set parcels = state_attr('sensor.parcel_raw_shipment_data', 'deliveries') or [] %}
+    {% set parcels = state_attr('sensor.parcel_app_parcel_raw_shipment_data', 'deliveries') or [] %}
     {% set enroute = namespace(list=[]) %}
     {% set delivered = namespace(list=[]) %}
 
@@ -31,7 +31,7 @@ filter:
       {% if statuscode in [2, 3, 4] %}
         {% set row = {
           'type': 'custom:template-entity-row',
-          'entity': 'sensor.parcel_raw_shipment_data',
+          'entity': 'sensor.parcel_app_parcel_raw_shipment_data',
           'name': '[' ~ carrier ~ '] ' ~ name ~ ' - ' ~ barcode,
           'state': 'En route',
           'secondary': 'Expected: ' ~ time,
@@ -41,7 +41,7 @@ filter:
       {% elif statuscode == 0 %}
         {% set row = {
           'type': 'custom:template-entity-row',
-          'entity': 'sensor.parcel_raw_shipment_data',
+          'entity': 'sensor.parcel_app_parcel_raw_shipment_data',
           'name': '[' ~ carrier ~ '] ' ~ name ~ ' - ' ~ barcode,
           'state': 'Delivered',
           'secondary': 'Delivered: ' ~ time,

--- a/docs/community_templates/bubble_card.yaml
+++ b/docs/community_templates/bubble_card.yaml
@@ -3,7 +3,7 @@
 
 type: markdown
 content: >-
-  {% set raw = state_attr('sensor.parcel_raw_shipment_data', 'deliveries') %}
+  {% set raw = state_attr('sensor.parcel_app_parcel_raw_shipment_data', 'deliveries') %}
   {% set ns = namespace(deliveries = []) %}
   {% for order in raw | selectattr('status_code','>',0) %}
     {% if order.date_expected is defined %}


### PR DESCRIPTION
The community template `docs/community_templates/bubble_card.yaml` still
references the old entity id `sensor.parcel_raw_shipment_data`.

Since the integration now creates the sensor as
`sensor.parcel_app_parcel_raw_shipment_data`, the template renders
empty for new installations (state_attr returns None).

This PR updates the entity id in the template accordingly.
Tested against v1.8.2 on Home Assistant 2026.8. 

Also updates README.md and auto_entities.yaml which referenced the same old entity id (5 occurrences across 3 files).