### PR TITLE
fix: replace deprecated device_registry.async_get_device (removed in HA 2027.8.0)

### DIFF
--- a/custom_components/parcelapp/__init__.py
+++ b/custom_components/parcelapp/__init__.py
@@ -77,9 +77,23 @@ async def async_update_entry(hass: HomeAssistant, config_entry: ParcelConfigEntr
 
 
 async def cleanup_old_device(hass: HomeAssistant) -> None:
-    """Cleanup device without proper device identifier."""
+    """Cleanup device without proper device identifier.
+
+    Older versions of this integration registered a device using a malformed
+    identifier -- a bare ``(DOMAIN,)`` tuple instead of the expected
+    ``(DOMAIN, <unique_id>)``. ``device_registry.async_get_device`` is
+    deprecated (scheduled for removal in HA Core 2027.8.0) because device
+    identifiers are no longer guaranteed unique across config entries, and it
+    cannot be used to look up the malformed single-element identifier anyway.
+
+    Iterate the device registry and remove any device that still carries the
+    improper identifier.
+    """
     device_reg = dr.async_get(hass)
-    device = device_reg.async_get_device(identifiers={(DOMAIN,)})
-    if device:
-        _LOGGER.debug("Removing improper device %s", device.name)
-        device_reg.async_remove_device(device.id)
+    for device in list(device_reg.devices.values()):
+        if any(
+            len(identifier) == 1 and identifier[0] == DOMAIN
+            for identifier in device.identifiers
+        ):
+            _LOGGER.debug("Removing improper device %s", device.name)
+            device_reg.async_remove_device(device.id)


### PR DESCRIPTION
## Summary
`cleanup_old_device()` calls `device_registry.async_get_device(identifiers={(DOMAIN,)})`. Home Assistant deprecated `async_get_device()` for identifier/connection lookups because device identifiers and connections are no longer unique across config entries. HA logs a warning on startup and this call **stops working in HA Core 2027.8.0**.

This PR replaces the deprecated lookup with an iteration over the device registry, matching the same malformed legacy identifier the original code was cleaning up.

## Why iterate instead of `async_get_device_by_identifier`?
The HA warning suggests `async_get_device_by_identifier`, but that helper takes a well-formed `(domain, id)` pair. The device this cleanup targets was registered with a **malformed** single-element identifier `(DOMAIN,)`, which cannot be expressed via `async_get_device_by_identifier`. Iterating the registry and matching the improper 1-tuple identifier preserves the original intent while removing the deprecated API usage.

(Note: the original `identifiers={(DOMAIN,)}` lookup was effectively a no-op, since a set containing a bare 1-tuple never matches a normally-registered device. The new code matches devices that actually carry that malformed identifier.)

## Testing
- `python -m pytest` -> **271 passed** (1 pre-existing unrelated tz warning).
- `python -m py_compile` passes.

## Deprecation reference
> Detected that custom integration 'parcelapp' calls `device_registry.async_get_device`, which is deprecated ... This will stop working in Home Assistant 2027.8.0.